### PR TITLE
Add 1.18 support

### DIFF
--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>Anvil</artifactId>
+        <groupId>me.explosivemine</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>anvil-1_18_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.18-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.explosivemine</groupId>
+            <artifactId>anvil-abstraction</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/1_18_R1/src/main/java/me/explosivemine/anvil/version/Wrapper1_18_R1.java
+++ b/1_18_R1/src/main/java/me/explosivemine/anvil/version/Wrapper1_18_R1.java
@@ -1,0 +1,97 @@
+package me.explosivemine.anvil.version;
+
+import me.explosivemine.anvil.version.abstraction.VersionWrapper;
+import net.minecraft.core.BlockPosition;
+import net.minecraft.network.chat.ChatMessage;
+import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.world.IInventory;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.inventory.*;
+import org.bukkit.craftbukkit.v1_18_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_18_R1.event.CraftEventFactory;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public class Wrapper1_18_R1 implements VersionWrapper {
+    private int getRealNextContainerId(Player player) {
+        return toNMS(player).nextContainerCounter();
+    }
+
+    @Override
+    public int getNextContainerId(Player player, Object container) {
+        return ((AnvilContainer) container).getContainerId();
+    }
+
+    @Override
+    public void handleInventoryCloseEvent(Player player) {
+        CraftEventFactory.handleInventoryCloseEvent(toNMS(player));
+    }
+
+    @Override
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, new ChatMessage(guiTitle)));
+    }
+
+    @Override
+    public void sendPacketCloseWindow(Player player, int containerId) {
+        toNMS(player).b.a(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void setActiveContainerDefault(Player player) {
+        toNMS(player).bW = toNMS(player).bV;
+    }
+
+    @Override
+    public void setActiveContainer(Player player, Object container) {
+        toNMS(player).bW = (Container) container;
+    }
+
+    @Override
+    public void setActiveContainerId(Object container, int containerId) { }
+
+    @Override
+    public void addActiveContainerSlotListener(Object container, Player player) {
+        toNMS(player).a((Container) container);
+    }
+
+    @Override
+    public Inventory toBukkitInventory(Object container) {
+        return ((Container) container).getBukkitView().getTopInventory();
+    }
+
+    @Override
+    public Object newContainerAnvil(Player player, String guiTitle) {
+        return new AnvilContainer(player, guiTitle);
+    }
+
+    private EntityPlayer toNMS(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    private class AnvilContainer extends ContainerAnvil {
+        public AnvilContainer(Player player, String guiTitle) {
+            super(getRealNextContainerId(player), ((CraftPlayer) player).getHandle().fq(),
+                    ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
+            this.checkReachable = false;
+            setTitle(new ChatMessage(guiTitle));
+        }
+
+        @Override
+        protected void a(EntityHuman entityhuman, IInventory iinventory) {
+        }
+
+        @Override
+        public void b(EntityHuman entityhuman) {
+        }
+
+        public int getContainerId() {
+            return this.j;
+        }
+
+    }
+
+}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -126,6 +126,12 @@
             <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>me.explosivemine</groupId>
+            <artifactId>anvil-1_18_R1</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/me/explosivemine/anvil/version/VersionMatcher.java
+++ b/api/src/main/java/me/explosivemine/anvil/version/VersionMatcher.java
@@ -3,6 +3,7 @@ package me.explosivemine.anvil.version;
 import me.explosivemine.anvil.version.abstraction.VersionWrapper;
 import org.bukkit.Bukkit;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,15 +16,15 @@ public class VersionMatcher {
             Wrapper1_11_R1.class, Wrapper1_12_R1.class, Wrapper1_13_R1.class,
             Wrapper1_13_R2.class, Wrapper1_14_R1.class, Wrapper1_15_R1.class,
             Wrapper1_16_R1.class, Wrapper1_16_R2.class, Wrapper1_16_R3.class,
-            Wrapper1_17_R1.class
+            Wrapper1_17_R1.class, Wrapper1_18_R1.class
         );
 
     public VersionWrapper match() {
         try {
             return versions.stream().filter(version -> version.getSimpleName().substring(7).equals(serverVersion))
                     .findFirst().orElseThrow(() -> new RuntimeException("Your server version is not supported by this plugin!"))
-                    .newInstance();
-        } catch (IllegalAccessException | InstantiationException ex) {
+                    .getDeclaredConstructor().newInstance();
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException ex) {
             throw new RuntimeException(ex);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>1_16_R2</module>
         <module>1_16_R3</module>
         <module>1_17_R1</module>
+        <module>1_18_R1</module>
         <module>core</module>
     </modules>
     <packaging>pom</packaging>


### PR DESCRIPTION
also replaced deprecated `Class.newInstance()` with `Class.getDeclaredConstructor().newInstance()` in anvil-api `VersionMatcher`